### PR TITLE
Migrate existing changes from patches

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "NFCPassportReader",
-    platforms: [.iOS("15.0")],
+    platforms: [.iOS("13.0")],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Sources/NFCPassportReader/BACHandler.swift
+++ b/Sources/NFCPassportReader/BACHandler.swift
@@ -12,7 +12,7 @@ import OSLog
 #if !os(macOS)
 import CoreNFC
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 public class BACHandler {
     let KENC : [UInt8] = [0,0,0,1]
     let KMAC : [UInt8] = [0,0,0,2]

--- a/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
+++ b/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
@@ -13,7 +13,7 @@ import OpenSSL
 import CoreNFC
 import CryptoKit
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 class ChipAuthenticationHandler {
     
     private static let NO_PACE_KEY_REFERENCE : UInt8 = 0x00

--- a/Sources/NFCPassportReader/DataGroupParser.swift
+++ b/Sources/NFCPassportReader/DataGroupParser.swift
@@ -19,13 +19,23 @@ class DataGroupParser {
                                       DataGroup15.self, NotImplementedDG.self, SOD.self]
     
     
-    func parseDG( data : [UInt8] ) throws -> DataGroup {
-        
+    func parseDG( data : [UInt8], ignoreErrors: Bool = false ) throws -> DataGroup {
+
         let header = data[0..<4]
         
         let dg = try tagToDG(header[0])
-
-        return try dg.init(data)
+        do {
+            return try dg.init(data)
+        } catch {
+            if ignoreErrors {
+                let failedDG = try FailedToParseDG(data)
+                failedDG.parseError = error
+                failedDG.failedToParseDGId = DataGroupId(rawValue: Int(header[0])) ?? .Unknown
+                return failedDG
+            } else {
+                throw error
+            }
+        }
     }
     
     

--- a/Sources/NFCPassportReader/DataGroups/COM.swift
+++ b/Sources/NFCPassportReader/DataGroups/COM.swift
@@ -20,6 +20,7 @@ public class COM : DataGroup {
     }
     
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         var tag = try getNextTag()
         try verifyTag(tag, equals: 0x5F01)
 

--- a/Sources/NFCPassportReader/DataGroups/DataGroup.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup.swift
@@ -21,15 +21,14 @@ public class DataGroup {
     required init( _ data : [UInt8] ) throws {
         self.data = data
         
-        // Skip the first byte which is the header byte
-        pos = 1
-        let _ = try getNextLength()
-        self.body = [UInt8](data[pos...])
-        
         try parse(data)
     }
     
     func parse( _ data:[UInt8] ) throws {
+        // Skip the first byte which is the header byte
+        pos = 1
+        let _ = try getNextLength()
+        self.body = [UInt8](data[pos...])
     }
     
     func getNextTag() throws -> Int {

--- a/Sources/NFCPassportReader/DataGroups/DataGroup1.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup1.swift
@@ -30,6 +30,7 @@ public class DataGroup1 : DataGroup {
     }
     
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         let tag = try getNextTag()
         try verifyTag(tag, equals: 0x5F1F)
         let body = try getNextValue()

--- a/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup11.swift
@@ -29,6 +29,7 @@ public class DataGroup11 : DataGroup {
     }
 
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         var tag = try getNextTag()
         try verifyTag(tag, equals: 0x5C)
         _ = try getNextValue()

--- a/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup12.swift
@@ -25,6 +25,7 @@ public class DataGroup12 : DataGroup {
     }
 
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         var tag = try getNextTag()
         try verifyTag(tag, equals: 0x5C)
 

--- a/Sources/NFCPassportReader/DataGroups/DataGroup14.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup14.swift
@@ -23,6 +23,7 @@ public class DataGroup14 : DataGroup {
     }
     
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         let p = SimpleASN1DumpParser()
         asn1 = try p.parse(data: Data(body))
         

--- a/Sources/NFCPassportReader/DataGroups/DataGroup15.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup15.swift
@@ -30,7 +30,8 @@ public class DataGroup15 : DataGroup {
     
     
     override func parse(_ data: [UInt8]) throws {
-        
+        try super.parse(data)
+
         // the public key can either be in EC (elliptic curve) or RSA format
         // Try ec first and if this fails try RSA
         // Note - this will be improved in a later version to read the ASN1 body to

--- a/Sources/NFCPassportReader/DataGroups/DataGroup2.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup2.swift
@@ -53,6 +53,7 @@ func getImage() -> UIImage? {
     }
 
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         var tag = try getNextTag()
         try verifyTag(tag, equals: 0x7F61)
         _ = try getNextLength()

--- a/Sources/NFCPassportReader/DataGroups/DataGroup7.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroup7.swift
@@ -34,6 +34,7 @@ public class DataGroup7 : DataGroup {
     
     
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         var tag = try getNextTag()
         try verifyTag(tag, equals: 0x02)
         _ = try getNextValue()

--- a/Sources/NFCPassportReader/DataGroups/FailedToParseDG.swift
+++ b/Sources/NFCPassportReader/DataGroups/FailedToParseDG.swift
@@ -1,0 +1,23 @@
+//
+//  FailedToParseDG.swift
+//  NFCPassportReader
+//
+//  Created by Mikhail Krasnenkov on 09/04/2025.
+//
+
+@available(iOS 13, macOS 10.15, *)
+public class FailedToParseDG: DataGroup {
+    override public var datagroupType: DataGroupId { failedToParseDGId }
+
+    var failedToParseDGId: DataGroupId = .Unknown
+
+    public internal(set) var parseError: any Error = NFCPassportReaderError.UnsupportedDataGroup
+
+    required init(_ data: [UInt8]) throws {
+        try super.init(data)
+    }
+
+    override func parse(_ data: [UInt8]) throws {
+        // Don't call super to skip parsing header
+    }
+}

--- a/Sources/NFCPassportReader/DataGroups/SOD.swift
+++ b/Sources/NFCPassportReader/DataGroups/SOD.swift
@@ -80,6 +80,7 @@ class SOD : DataGroup {
     }
 
     override func parse(_ data: [UInt8]) throws {
+        try super.parse(data)
         let p = SimpleASN1DumpParser()
         asn1 = try p.parse(data: Data(body))
     }

--- a/Sources/NFCPassportReader/Logging.swift
+++ b/Sources/NFCPassportReader/Logging.swift
@@ -7,8 +7,6 @@
 //
 
 import Foundation
-import OSLog
-
 
 extension Logger {
     /// Using your bundle identifier is a great way to ensure a unique identifier.
@@ -30,3 +28,18 @@ extension Logger {
     static let pace = Logger(subsystem: subsystem, category: "PACE")
 }
 
+// This disables logging, as simplest way to achieve iOS 13 support
+struct Logger : @unchecked Sendable {
+    init(subsystem: String, category: String) {}
+
+    func log(_ message: String) {}
+
+    func trace(_ message: String) {}
+    func debug(_ message: String) {}
+    func info(_ message: String) {}
+    func notice(_ message: String) {}
+    func warning(_ message: String) {}
+    func error(_ message: String) {}
+    func critical(_ message: String) {}
+    func fault(_ message: String) {}
+}

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -14,7 +14,7 @@ import CryptoTokenKit
 import CoreNFC
 import CryptoKit
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 private enum PACEHandlerError {
     case DHKeyAgreementError(String)
     case ECDHKeyAgreementError(String)
@@ -28,14 +28,14 @@ private enum PACEHandlerError {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 extension PACEHandlerError: LocalizedError {
     public var errorDescription: String? {
         return NSLocalizedString(value, comment: "PACEHandlerError")
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 public class PACEHandler {
     
     
@@ -390,7 +390,7 @@ public class PACEHandler {
 }
 
 // MARK - PACEHandler Utility functions
-@available(iOS 15, *)
+@available(iOS 13, *)
 extension PACEHandler {
     
     /// Does the DH key Mapping agreement

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -13,7 +13,7 @@ import OSLog
 import UIKit
 import CoreNFC
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 public protocol PassportReaderTrackingDelegate: AnyObject {
     func nfcTagDetected()
     func readCardAccess(cardAccess: CardAccess)
@@ -25,7 +25,7 @@ public protocol PassportReaderTrackingDelegate: AnyObject {
     func bacFailed()
 }
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 extension PassportReaderTrackingDelegate {
     func nfcTagDetected() { /* default implementation */ }
     func readCardAccess(cardAccess: CardAccess) { /* default implementation */ }
@@ -37,7 +37,7 @@ extension PassportReaderTrackingDelegate {
     func bacFailed() { /* default implementation */ }
 }
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 public class PassportReader : NSObject {
     private typealias NFCCheckedContinuation = CheckedContinuation<NFCPassportModel, Error>
     private var nfcContinuation: NFCCheckedContinuation?
@@ -134,7 +134,7 @@ public class PassportReader : NSObject {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 extension PassportReader : NFCTagReaderSessionDelegate {
     // MARK: - NFCTagReaderSessionDelegate
     public func tagReaderSessionDidBecomeActive(_ session: NFCTagReaderSession) {
@@ -252,7 +252,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 extension PassportReader {
     
     func startReading(tagReader : TagReader) async throws -> NFCPassportModel {

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -89,9 +89,16 @@ public class PassportReader : NSObject {
     public func overrideNFCDataAmountToRead( amount: Int ) {
         dataAmountToReadOverride = amount
     }
-    
-    public func readPassport( mrzKey : String, tags : [DataGroupId] = [], skipSecureElements : Bool = true, skipCA : Bool = false, skipPACE : Bool = false, useExtendedMode : Bool = false, customDisplayMessage : ((NFCViewDisplayMessage) -> String?)? = nil) async throws -> NFCPassportModel {
-        
+
+    public func readPassport(
+        mrzKey : String,
+        tags : [DataGroupId] = [],
+        skipSecureElements : Bool = true,
+        skipCA : Bool = false,
+        skipPACE : Bool = false,
+        useExtendedMode : Bool = false,
+        customDisplayMessage : (@Sendable (NFCViewDisplayMessage) -> String?)? = nil
+    ) async throws -> NFCPassportModel {
         self.passport = NFCPassportModel()
         self.mrzKey = mrzKey
         self.skipCA = skipCA

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -12,7 +12,7 @@ import OSLog
 #if !os(macOS)
 import CoreNFC
 
-@available(iOS 15, *)
+@available(iOS 13, *)
 public class TagReader {
     var tag : NFCISO7816Tag
     var secureMessaging : SecureMessaging?


### PR DESCRIPTION
These include:

- Downgrade minimum deploy version to iOS 13
- Option to ignore datagroup parse errors

Current patch also contains other changes that are not include as they did not prove useful:

- Adding `@unchecked Sendable` conformances to public types — should use actor isolation in the client instead
- Option to provide external active authentication challenge — was not used
- OpenSSL3 support is now in upstream